### PR TITLE
Linting Fix

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -16,9 +16,8 @@ jobs:
               uses: actions/setup-go@v6
               with:
                 go-version-file: go.mod
-            # TODO: Re-enable linting after fixing existing issues on alioss
-            # - name: Lint code
-            #   uses: golangci/golangci-lint-action@v8
+            - name: Lint code
+              uses: golangci/golangci-lint-action@v8
             - name: Cache Go modules
               uses: actions/cache@v4
               with:

--- a/alioss/client/client.go
+++ b/alioss/client/client.go
@@ -63,7 +63,7 @@ func (client *AliBlobstore) getMD5(filePath string) (string, error) {
 		return "", err
 	}
 
-	defer file.Close()
+	defer file.Close() //nolint:errcheck
 
 	hash := md5.New()
 	_, err = io.Copy(hash, file)

--- a/alioss/client/client_test.go
+++ b/alioss/client/client_test.go
@@ -19,9 +19,9 @@ var _ = Describe("Client", func() {
 			aliBlobstore, err := client.New(&storageClient)
 			Expect(err).ToNot(HaveOccurred())
 
-			tmpFile, err := os.CreateTemp("", "azure-storage-cli-test")
+			tmpFile, _ := os.CreateTemp("", "azure-storage-cli-test") //nolint:errcheck
 
-			aliBlobstore.Put(tmpFile.Name(), "destination_object")
+			aliBlobstore.Put(tmpFile.Name(), "destination_object") //nolint:errcheck
 
 			Expect(storageClient.UploadCallCount()).To(Equal(1))
 			sourceFilePath, sourceFileMD5, destination := storageClient.UploadArgsForCall(0)
@@ -39,7 +39,7 @@ var _ = Describe("Client", func() {
 			aliBlobstore, err := client.New(&storageClient)
 			Expect(err).ToNot(HaveOccurred())
 
-			aliBlobstore.Get("source_object", "destination/file/path")
+			aliBlobstore.Get("source_object", "destination/file/path") //nolint:errcheck
 
 			Expect(storageClient.DownloadCallCount()).To(Equal(1))
 			sourceObject, destinationFilePath := storageClient.DownloadArgsForCall(0)
@@ -56,7 +56,7 @@ var _ = Describe("Client", func() {
 			aliBlobstore, err := client.New(&storageClient)
 			Expect(err).ToNot(HaveOccurred())
 
-			aliBlobstore.Delete("blob")
+			aliBlobstore.Delete("blob") //nolint:errcheck
 
 			Expect(storageClient.DeleteCallCount()).To(Equal(1))
 			object := storageClient.DeleteArgsForCall(0)
@@ -70,7 +70,8 @@ var _ = Describe("Client", func() {
 			storageClient := clientfakes.FakeStorageClient{}
 			storageClient.ExistsReturns(true, nil)
 
-			aliBlobstore, _ := client.New(&storageClient)
+			aliBlobstore, err := client.New(&storageClient)
+			Expect(err).NotTo(HaveOccurred())
 			existsState, err := aliBlobstore.Exists("blob")
 			Expect(existsState == true).To(BeTrue())
 			Expect(err).ToNot(HaveOccurred())
@@ -83,7 +84,8 @@ var _ = Describe("Client", func() {
 			storageClient := clientfakes.FakeStorageClient{}
 			storageClient.ExistsReturns(false, nil)
 
-			aliBlobstore, _ := client.New(&storageClient)
+			aliBlobstore, err := client.New(&storageClient)
+			Expect(err).NotTo(HaveOccurred())
 			existsState, err := aliBlobstore.Exists("blob")
 			Expect(existsState == false).To(BeTrue())
 			Expect(err).ToNot(HaveOccurred())
@@ -96,7 +98,8 @@ var _ = Describe("Client", func() {
 			storageClient := clientfakes.FakeStorageClient{}
 			storageClient.ExistsReturns(false, errors.New("boom"))
 
-			aliBlobstore, _ := client.New(&storageClient)
+			aliBlobstore, err := client.New(&storageClient)
+			Expect(err).NotTo(HaveOccurred())
 			existsState, err := aliBlobstore.Exists("blob")
 			Expect(existsState == false).To(BeTrue())
 			Expect(err).To(HaveOccurred())
@@ -111,7 +114,8 @@ var _ = Describe("Client", func() {
 			storageClient := clientfakes.FakeStorageClient{}
 			storageClient.SignedUrlGetReturns("https://the-signed-url", nil)
 
-			aliBlobstore, _ := client.New(&storageClient)
+			aliBlobstore, err := client.New(&storageClient)
+			Expect(err).NotTo(HaveOccurred())
 			url, err := aliBlobstore.Sign("blob", "get", 100)
 			Expect(url == "https://the-signed-url").To(BeTrue())
 			Expect(err).ToNot(HaveOccurred())
@@ -125,7 +129,8 @@ var _ = Describe("Client", func() {
 			storageClient := clientfakes.FakeStorageClient{}
 			storageClient.SignedUrlPutReturns("https://the-signed-url", nil)
 
-			aliBlobstore, _ := client.New(&storageClient)
+			aliBlobstore, err := client.New(&storageClient)
+			Expect(err).NotTo(HaveOccurred())
 			url, err := aliBlobstore.Sign("blob", "put", 100)
 			Expect(url == "https://the-signed-url").To(BeTrue())
 			Expect(err).ToNot(HaveOccurred())
@@ -139,7 +144,8 @@ var _ = Describe("Client", func() {
 			storageClient := clientfakes.FakeStorageClient{}
 			storageClient.SignedUrlGetReturns("", errors.New("boom"))
 
-			aliBlobstore, _ := client.New(&storageClient)
+			aliBlobstore, err := client.New(&storageClient)
+			Expect(err).NotTo(HaveOccurred())
 			url, err := aliBlobstore.Sign("blob", "unknown", 100)
 			Expect(url).To(Equal(""))
 			Expect(err).To(HaveOccurred())

--- a/alioss/client/storage_client.go
+++ b/alioss/client/storage_client.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
@@ -53,7 +52,7 @@ func (dsc DefaultStorageClient) Upload(
 	sourceFileMD5 string,
 	destinationObject string,
 ) error {
-	log.Println(fmt.Sprintf("Uploading %s/%s", dsc.storageConfig.BucketName, destinationObject))
+	log.Printf("Uploading %s/%s\n", dsc.storageConfig.BucketName, destinationObject)
 
 	client, err := oss.New(dsc.storageConfig.Endpoint, dsc.storageConfig.AccessKeyID, dsc.storageConfig.AccessKeySecret)
 	if err != nil {
@@ -72,7 +71,7 @@ func (dsc DefaultStorageClient) Download(
 	sourceObject string,
 	destinationFilePath string,
 ) error {
-	log.Println(fmt.Sprintf("Downloading %s/%s", dsc.storageConfig.BucketName, sourceObject))
+	log.Printf("Downloading %s/%s\n", dsc.storageConfig.BucketName, sourceObject)
 
 	client, err := oss.New(dsc.storageConfig.Endpoint, dsc.storageConfig.AccessKeyID, dsc.storageConfig.AccessKeySecret)
 	if err != nil {
@@ -90,7 +89,7 @@ func (dsc DefaultStorageClient) Download(
 func (dsc DefaultStorageClient) Delete(
 	object string,
 ) error {
-	log.Println(fmt.Sprintf("Deleting %s/%s", dsc.storageConfig.BucketName, object))
+	log.Printf("Deleting %s/%s\n", dsc.storageConfig.BucketName, object)
 
 	client, err := oss.New(dsc.storageConfig.Endpoint, dsc.storageConfig.AccessKeyID, dsc.storageConfig.AccessKeySecret)
 	if err != nil {
@@ -106,7 +105,7 @@ func (dsc DefaultStorageClient) Delete(
 }
 
 func (dsc DefaultStorageClient) Exists(object string) (bool, error) {
-	log.Println(fmt.Sprintf("Checking if blob: %s/%s", dsc.storageConfig.BucketName, object))
+	log.Printf("Checking if blob: %s/%s\n", dsc.storageConfig.BucketName, object)
 
 	client, err := oss.New(dsc.storageConfig.Endpoint, dsc.storageConfig.AccessKeyID, dsc.storageConfig.AccessKeySecret)
 	if err != nil {
@@ -137,7 +136,7 @@ func (dsc DefaultStorageClient) SignedUrlPut(
 	expiredInSec int64,
 ) (string, error) {
 
-	log.Println(fmt.Sprintf("Getting signed PUT url for blob %s/%s", dsc.storageConfig.BucketName, object))
+	log.Printf("Getting signed PUT url for blob %s/%s\n", dsc.storageConfig.BucketName, object)
 
 	client, err := oss.New(dsc.storageConfig.Endpoint, dsc.storageConfig.AccessKeyID, dsc.storageConfig.AccessKeySecret)
 	if err != nil {
@@ -157,7 +156,7 @@ func (dsc DefaultStorageClient) SignedUrlGet(
 	expiredInSec int64,
 ) (string, error) {
 
-	log.Println(fmt.Sprintf("Getting signed GET url for blob %s/%s", dsc.storageConfig.BucketName, object))
+	log.Printf("Getting signed GET url for blob %s/%s\n", dsc.storageConfig.BucketName, object)
 
 	client, err := oss.New(dsc.storageConfig.Endpoint, dsc.storageConfig.AccessKeyID, dsc.storageConfig.AccessKeySecret)
 	if err != nil {

--- a/alioss/integration/general_ali_test.go
+++ b/alioss/integration/general_ali_test.go
@@ -2,7 +2,7 @@ package integration_test
 
 import (
 	"bytes"
-	"io/ioutil"
+
 	"os"
 
 	"github.com/cloudfoundry/storage-cli/alioss/config"
@@ -25,8 +25,8 @@ var _ = Describe("General testing for all Ali regions", func() {
 	})
 
 	AfterEach(func() {
-		defer func() { _ = os.Remove(configPath) }()
-		defer func() { _ = os.Remove(contentFile) }()
+		defer func() { _ = os.Remove(configPath) }()  //nolint:errcheck
+		defer func() { _ = os.Remove(contentFile) }() //nolint:errcheck
 	})
 
 	Describe("Invoking `put`", func() {
@@ -55,9 +55,9 @@ var _ = Describe("General testing for all Ali regions", func() {
 				Expect(cliSession.ExitCode()).To(BeZero())
 			}()
 
-			tmpLocalFile, _ := os.CreateTemp("", "ali-storage-cli-download")
-			tmpLocalFile.Close()
-			defer func() { _ = os.Remove(tmpLocalFile.Name()) }()
+			tmpLocalFile, _ := os.CreateTemp("", "ali-storage-cli-download") //nolint:errcheck
+			tmpLocalFile.Close()                                             //nolint:errcheck
+			defer func() { _ = os.Remove(tmpLocalFile.Name()) }()            //nolint:errcheck
 
 			contentFile = integration.MakeContentFile("initial content")
 			cliSession, err := integration.RunCli(cliPath, configPath, "put", contentFile, blobName)
@@ -68,7 +68,7 @@ var _ = Describe("General testing for all Ali regions", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cliSession.ExitCode()).To(BeZero())
 
-			gottenBytes, _ := os.ReadFile(tmpLocalFile.Name())
+			gottenBytes, _ := os.ReadFile(tmpLocalFile.Name()) //nolint:errcheck
 			Expect(string(gottenBytes)).To(Equal("initial content"))
 
 			contentFile = integration.MakeContentFile("updated content")
@@ -80,7 +80,7 @@ var _ = Describe("General testing for all Ali regions", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cliSession.ExitCode()).To(BeZero())
 
-			gottenBytes, _ = os.ReadFile(tmpLocalFile.Name())
+			gottenBytes, _ = os.ReadFile(tmpLocalFile.Name()) //nolint:errcheck
 			Expect(string(gottenBytes)).To(Equal("updated content"))
 		})
 
@@ -112,7 +112,7 @@ var _ = Describe("General testing for all Ali regions", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(cliSession.ExitCode()).To(BeZero())
 
-				_ = os.Remove(outputFilePath)
+				_ = os.Remove(outputFilePath) //nolint:errcheck
 			}()
 
 			cliSession, err := integration.RunCli(cliPath, configPath, "put", contentFile, blobName)
@@ -123,7 +123,7 @@ var _ = Describe("General testing for all Ali regions", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cliSession.ExitCode()).To(BeZero())
 
-			fileContent, _ := ioutil.ReadFile(outputFilePath)
+			fileContent, _ := os.ReadFile(outputFilePath) //nolint:errcheck
 			Expect(string(fileContent)).To(Equal("foo"))
 		})
 	})
@@ -200,7 +200,7 @@ var _ = Describe("General testing for all Ali regions", func() {
 	Describe("Invoking `-v`", func() {
 		It("returns the cli version", func() {
 			configPath := integration.MakeConfigFile(&defaultConfig)
-			defer func() { _ = os.Remove(configPath) }()
+			defer func() { _ = os.Remove(configPath) }() //nolint:errcheck
 
 			cliSession, err := integration.RunCli(cliPath, configPath, "-v")
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
# Problem
Linting error in ./alioss source code was preventing to run linting step in worklfow

# Fix
Linting errors are resolved.  **nolint:errcheck** linter comment is used based on the reference from other source code in same repo. Deprecated ioutil.ReadFile is removed. log.Printf used instead of log.Println based on the https://staticcheck.dev/docs/checks/#S1038