### PR TITLE
Github Environment Tag Removed

### DIFF
--- a/.github/workflows/gcs-integration.yml
+++ b/.github/workflows/gcs-integration.yml
@@ -10,7 +10,6 @@ jobs:
   gcs-integration-fast-tests:
     name:  GCS Integation Fast Tests
     runs-on: ubuntu-latest
-    environment: gcs-integration
     steps:
       - name: Checkout code
         uses: actions/checkout@v5     
@@ -41,7 +40,6 @@ jobs:
   gcs-integration-all-tests:
     name:  GCS Integation All Tests
     runs-on: ubuntu-latest
-    environment: gcs-integration
     steps:
       - name: Checkout code
         uses: actions/checkout@v5      


### PR DESCRIPTION
# Problem
With environments, we need admin access to the repo for maintaining env secrets. The org automation doesn’t grant admin rights but only write access to the repos so that an approver can’t e.g. delete a repo.

# Solution
Environment tag removed from workflow.
