### PR TITLE
Release Pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version-file: 'go.mod'
+        go-version-file: go.mod
     
     - name: Storage-CLI Build for Linux
       env:

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -1,4 +1,4 @@
-name : Release
+name : Release Auto
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # DEFAULT_BUMP is used when there are no MAJOR_STRING_TOKEN or MINOR_STRING_TOKEN, 
-          # or for manual workflow_dispatch override
+          # or for manual workflow_dispatch
           DEFAULT_BUMP: ${{ github.event.inputs.version_bump || 'patch'}}
           WITH_V: true
           MAJOR_STRING_TOKEN: "BREAKING CHANGE:"
@@ -119,16 +119,16 @@ jobs:
             storage-cli-${{ env.VERSION_NUMBER }}-windows-amd64.exe
           token: ${{ secrets.GITHUB_TOKEN }}
       
-      - name: Configure AWS
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
+      # - name: Configure AWS
+      #   uses: aws-actions/configure-aws-credentials@v4
+      #   with:
+      #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      #     aws-region: us-east-1
 
-      - name: Upload Artifacts to S3
-        run: |
-            aws s3 cp "storage-cli-${{ env.VERSION_NUMBER }}-linux-amd64" \
-              "s3://storage-cli-artifacts/storage-cli-${{ env.VERSION_NUMBER }}-linux-amd64"
-            aws s3 cp "storage-cli-${{ env.VERSION_NUMBER }}-windows-amd64.exe" \
-            "s3://storage-cli-artifacts/storage-cli-${{ env.VERSION_NUMBER }}-windows-amd64.exe"   
+      # - name: Upload Artifacts to S3
+      #   run: |
+      #       aws s3 cp "storage-cli-${{ env.VERSION_NUMBER }}-linux-amd64" \
+      #         "s3://storage-cli-artifacts/storage-cli-${{ env.VERSION_NUMBER }}-linux-amd64"
+      #       aws s3 cp "storage-cli-${{ env.VERSION_NUMBER }}-windows-amd64.exe" \
+      #       "s3://storage-cli-artifacts/storage-cli-${{ env.VERSION_NUMBER }}-windows-amd64.exe"   

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,6 @@ name : Release
 
 on:
   push:
-    branches: [ "main","feature/release-pipeline"]
-  pull_request:
     branches: [ main ]
   workflow_dispatch:
     inputs:
@@ -57,8 +55,14 @@ jobs:
         uses: anothrNick/github-tag-action@1.70.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # DEFAULT_BUMP is used when no conventional commit tokens are found, or for manual workflow_dispatch override
           DEFAULT_BUMP: ${{ github.event.inputs.version_bump || 'patch'}}
           WITH_V: true
+          MAJOR_STRING_TOKEN: "BREAKING CHANGE:,breaking change:,Breaking Change:"
+          MINOR_STRING_TOKEN: "feat:,Feat:,FEAT:"
+          PATCH_STRING_TOKEN: "fix:,Fix:,FIX:"
+          NONE_STRING_TOKEN: "chore:,docs:,test:,ci:,refactor:,style:,build:,Chore:,Docs:,Test:,CI:,Refactor:,Style:,Build:"
+          PRERELEASE: false
 
       - name: Export Version Variable
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,13 +55,12 @@ jobs:
         uses: anothrNick/github-tag-action@1.70.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # DEFAULT_BUMP is used when no conventional commit tokens are found, or for manual workflow_dispatch override
+          # DEFAULT_BUMP is used when there are no MAJOR_STRING_TOKEN or MINOR_STRING_TOKEN, 
+          # or for manual workflow_dispatch override
           DEFAULT_BUMP: ${{ github.event.inputs.version_bump || 'patch'}}
           WITH_V: true
-          MAJOR_STRING_TOKEN: "BREAKING CHANGE:,breaking change:,Breaking Change:"
-          MINOR_STRING_TOKEN: "feat:,Feat:,FEAT:"
-          PATCH_STRING_TOKEN: "fix:,Fix:,FIX:"
-          NONE_STRING_TOKEN: "chore:,docs:,test:,ci:,refactor:,style:,build:,Chore:,Docs:,Test:,CI:,Refactor:,Style:,Build:"
+          MAJOR_STRING_TOKEN: "BREAKING CHANGE:"
+          MINOR_STRING_TOKEN: "feat:"
           PRERELEASE: false
 
       - name: Export Version Variable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,19 +17,22 @@ on:
           - minor
           - major
 
-
 jobs:
   tests: 
     name: Run Unit Tests
     runs-on: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v5
+      - name: Checkout Into Source Code
+        uses: actions/checkout@v5
+
       - name: Set up Go    
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+
       - name: Lint code
         uses: golangci/golangci-lint-action@v8
+
       - name: Run Unit Tests
         run: |
               export CGO_ENABLED=0
@@ -102,7 +105,7 @@ jobs:
               sha1sum "storage-cli-${{ env.VERSION_NUMBER }}-windows-amd64.exe" >> $GITHUB_STEP_SUMMARY
               echo '```' >> $GITHUB_STEP_SUMMARY
       
-      - name: Create Release
+      - name: Create Github Release
         uses: ncipollo/release-action@v1
         with:
           tag: ${{ steps.tag_version.outputs.new_tag }}
@@ -113,7 +116,7 @@ jobs:
             storage-cli-${{ env.VERSION_NUMBER }}-windows-amd64.exe
           token: ${{ secrets.GITHUB_TOKEN }}
       
-      - name: Configure AWS credentials
+      - name: Configure AWS
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -125,8 +128,4 @@ jobs:
             aws s3 cp "storage-cli-${{ env.VERSION_NUMBER }}-linux-amd64" \
               "s3://storage-cli-artifacts/storage-cli-${{ env.VERSION_NUMBER }}-linux-amd64"
             aws s3 cp "storage-cli-${{ env.VERSION_NUMBER }}-windows-amd64.exe" \
-            "s3://storage-cli-artifacts/storage-cli-${{ env.VERSION_NUMBER }}-windows-amd64.exe"
-          
-          
-        
-      
+            "s3://storage-cli-artifacts/storage-cli-${{ env.VERSION_NUMBER }}-windows-amd64.exe"   

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,132 @@
+name : Release
+
+on:
+  push:
+    branches: [ "main","feature/release-pipeline"]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: 'version bump type'
+        required: false
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+
+jobs:
+  tests: 
+    name: Run Unit Tests
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up Go    
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - name: Lint code
+        uses: golangci/golangci-lint-action@v8
+      - name: Run Unit Tests
+        run: |
+              export CGO_ENABLED=0
+              go version
+              go run github.com/onsi/ginkgo/v2/ginkgo --skip-package=integration ./...
+
+  build-and-release:
+    name: Build and Release
+    needs: tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Into Source Code
+        uses: actions/checkout@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Bump Version and Create Tag
+        id: tag_version
+        uses: anothrNick/github-tag-action@1.70.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEFAULT_BUMP: ${{ github.event.inputs.version_bump || 'patch'}}
+          WITH_V: true
+
+      - name: Export Version Variable
+        run: |
+          VERSION=${{steps.tag_version.outputs.new_tag}}
+          VERSION_NUMBER=${VERSION#v}
+          echo "VERSION_NUMBER=${VERSION_NUMBER}" >> $GITHUB_ENV
+
+      - name: Generate Changelog
+        id: changelog
+        uses: mikepenz/release-changelog-builder-action@v5
+        with:
+          toTag: ${{ steps.tag_version.outputs.new_tag }}
+          commitMode: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build for Linux
+        env:
+          GOOS: linux
+          GOARCH: amd64
+          CGO_ENABLED: 0
+          VERSION: ${{ steps.tag_version.outputs.new_tag}}
+        run: |
+              echo "Building Storage CLI for Linux"
+              go build -ldflags "-X main.version=${{ env.VERSION_NUMBER }}" \
+              -o "storage-cli-${{ env.VERSION_NUMBER }}-linux-amd64"
+              echo "### Linux Build Checksums" >> $GITHUB_STEP_SUMMARY
+              echo '```' >> $GITHUB_STEP_SUMMARY
+              sha1sum "storage-cli-${{ env.VERSION_NUMBER }}-linux-amd64" >> $GITHUB_STEP_SUMMARY
+              echo '```' >> $GITHUB_STEP_SUMMARY
+      
+      - name: Build for Windows
+        env:
+          GOOS: windows
+          GOARCH: amd64
+          CGO_ENABLED: 0
+          VERSION: ${{ steps.tag_version.outputs.new_tag }}
+        run: |
+              echo "Building Storage CLI for Windows"
+              go build -ldflags "-X main.version=${{ env.VERSION_NUMBER }}" \
+              -o "storage-cli-${{ env.VERSION_NUMBER }}-windows-amd64.exe"
+              echo "### Windows Build Checksums" >> $GITHUB_STEP_SUMMARY
+              echo '```' >> $GITHUB_STEP_SUMMARY
+              sha1sum "storage-cli-${{ env.VERSION_NUMBER }}-windows-amd64.exe" >> $GITHUB_STEP_SUMMARY
+              echo '```' >> $GITHUB_STEP_SUMMARY
+      
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          name: Release ${{ steps.tag_version.outputs.new_tag }}
+          body: ${{ steps.changelog.outputs.changelog }}
+          artifacts: |
+            storage-cli-${{ env.VERSION_NUMBER }}-linux-amd64
+            storage-cli-${{ env.VERSION_NUMBER }}-windows-amd64.exe
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload Artifacts to S3
+        run: |
+            aws s3 cp "storage-cli-${{ env.VERSION_NUMBER }}-linux-amd64" \
+              "s3://storage-cli-artifacts/storage-cli-${{ env.VERSION_NUMBER }}-linux-amd64"
+            aws s3 cp "storage-cli-${{ env.VERSION_NUMBER }}-windows-amd64.exe" \
+            "s3://storage-cli-artifacts/storage-cli-${{ env.VERSION_NUMBER }}-windows-amd64.exe"
+          
+          
+        
+      

--- a/README.md
+++ b/README.md
@@ -143,19 +143,18 @@ When changes are merged into the `main` branch, a new release is automatically t
 
 **Version Bump Rules:**
 - `feat:` - New feature → **Minor version bump** (v1.2.0 → v1.3.0)
-- `fix:` - Bug fix → **Patch version bump** (v1.2.0 → v1.2.1)
 - `BREAKING CHANGE:` - Breaking changes → **Major version bump** (v1.2.0 → v2.0.0)
-- 
-
-**No Release Triggered:**
-- `docs:` - Documentation changes
-- `chore:` - Maintenance tasks (dependencies, build config, tooling)
-- `refactor:` - Code restructuring without behavior changes
-- `test:` - Test updates
-- `style:` - Formatting and whitespace
-- `ci:` - CI/CD configuration changes
-- `perf:` - Performance improvements
-- `build:` - Dependabot commits
+- Patch version bump (v1.2.0 → v1.2.1)
+    - `fix:` - Bug fix
+    - `docs:` - Documentation changes
+    - `chore:` - Maintenance tasks (dependencies, build config, tooling)
+    - `refactor:` - Code restructuring without behavior changes
+    - `test:` - Test updates
+    - `style:` - Formatting and whitespace
+    - `ci:` - CI/CD configuration changes
+    - `perf:` - Performance improvements
+    - `build:` - Dependabot commits
+    - `no conventional commits` - text without specifying any of above
 
 ### Manual Release
 
@@ -164,20 +163,18 @@ For manual releases (e.g., major version updates or hotfixes), use the GitHub Ac
 ### Commit Message Examples
 
 ```bash
-# Patch release (v1.2.3 → v1.2.4)
-git commit -m "fix: resolve upload timeout issue"
-
-# Minor release (v1.2.3 → v1.3.0)
-git commit -m "feat: add retry logic for failed uploads"
-
 # Major release (v1.2.3 → v2.0.0)
 git commit -m "feat: redesign upload API
 
 BREAKING CHANGE: Upload() signature changed to return structured error"
 
-# No release
+# Minor release (v1.2.3 → v1.3.0)
+git commit -m "feat: add retry logic for failed uploads"
+
+# Patch release (v1.2.3 → v1.2.4)
 git commit -m "docs: update Azure Blob Storage usage examples"
 git commit -m "chore: upgrade dependencies"
+git commit -m "class x moved to another folder"
 ```
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Follow these steps to make a contribution to the project:
   ```
 - If you added or modified integration tests, to run them locally, follow the instructions in the provider-specific README (see [Providers](#providers) section)
 - Push changes to your fork
+  Before writing commit message check [release section](#automated-release-process) and [commit message examples](#commit-message-examples)
   ``` bash
   git add .
   git commit -m "Commit message"

--- a/README.md
+++ b/README.md
@@ -133,11 +133,7 @@ Option 2: Release via Draft Release
 - The release will appear immediately on the Releases page. This action will also trigger the *Release Manual* workflow, which will build the artifacts and upload them to the published release once the workflow finishes.
 
 
-## Release
-
-Releases are automatically created for Windows and Linux platforms through the `release.yml` GitHub Actions workflow.
-
-### Automated Release Process
+### Automated Release
 
 When changes are merged into the `main` branch, a new release is automatically triggered. The version number is determined using **semantic versioning** based on conventional commit message prefixes:
 
@@ -156,11 +152,9 @@ When changes are merged into the `main` branch, a new release is automatically t
     - `build:` - Dependabot commits
     - `no conventional commits` - text without specifying any of above
 
-### Manual Release
+**Note: When the repo becomes more stable, we are gonna merge these 2 release logic.**
 
-For manual releases (e.g., major version updates or hotfixes), use the GitHub Actions **workflow_dispatch** trigger with a version bump type selector (patch/minor/major).
-
-### Commit Message Examples
+#### Commit Message Examples
 
 ```bash
 # Major release (v1.2.3 → v2.0.0)

--- a/README.md
+++ b/README.md
@@ -132,6 +132,53 @@ Option 2: Release via Draft Release
 - The release will appear immediately on the Releases page. This action will also trigger the *Release Manual* workflow, which will build the artifacts and upload them to the published release once the workflow finishes.
 
 
+## Release
+
+Releases are automatically created for Windows and Linux platforms through the `release.yml` GitHub Actions workflow.
+
+### Automated Release Process
+
+When changes are merged into the `main` branch, a new release is automatically triggered. The version number is determined using **semantic versioning** based on conventional commit message prefixes:
+
+**Version Bump Rules:**
+- `feat:` - New feature → **Minor version bump** (v1.2.0 → v1.3.0)
+- `fix:` - Bug fix → **Patch version bump** (v1.2.0 → v1.2.1)
+- `BREAKING CHANGE:` - Breaking changes → **Major version bump** (v1.2.0 → v2.0.0)
+- 
+
+**No Release Triggered:**
+- `docs:` - Documentation changes
+- `chore:` - Maintenance tasks (dependencies, build config, tooling)
+- `refactor:` - Code restructuring without behavior changes
+- `test:` - Test updates
+- `style:` - Formatting and whitespace
+- `ci:` - CI/CD configuration changes
+- `perf:` - Performance improvements
+- `build:` - Dependabot commits
+
+### Manual Release
+
+For manual releases (e.g., major version updates or hotfixes), use the GitHub Actions **workflow_dispatch** trigger with a version bump type selector (patch/minor/major).
+
+### Commit Message Examples
+
+```bash
+# Patch release (v1.2.3 → v1.2.4)
+git commit -m "fix: resolve upload timeout issue"
+
+# Minor release (v1.2.3 → v1.3.0)
+git commit -m "feat: add retry logic for failed uploads"
+
+# Major release (v1.2.3 → v2.0.0)
+git commit -m "feat: redesign upload API
+
+BREAKING CHANGE: Upload() signature changed to return structured error"
+
+# No release
+git commit -m "docs: update Azure Blob Storage usage examples"
+git commit -m "chore: upgrade dependencies"
+```
+
 ## Notes
 These commit IDs represent the last migration checkpoint from each provider's original repository, marking the final commit that was copied during the consolidation process.
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Follow these steps to make a contribution to the project:
   ```
 - If you added or modified integration tests, to run them locally, follow the instructions in the provider-specific README (see [Providers](#providers) section)
 - Push changes to your fork
-  Before writing commit message check [release section](#automated-release-process) and [commit message examples](#commit-message-examples)
+- **IMPORTANT:** Before writing commit message check [release section](#automated-release-process) and [commit message examples](#commit-message-examples)
   ``` bash
   git add .
   git commit -m "Commit message"


### PR DESCRIPTION
# Context
In the original repositories, each storage CLI had its own release pipeline responsible for tagging, creating releases, and uploading artifacts to an S3 bucket.

# Solution
We introduced a unified release pipeline that runs unit tests as a sanity check and then performs the following steps in order:
- Bumps the version according to the defined logic
- Generates the changelog
- Builds the source code for Linux and Windows
- Publishes the release on GitHub

## Release Versioning
**Version Bump Rules:**
- `feat:` - New feature → **Minor version bump** (v1.2.0 → v1.3.0)
- `BREAKING CHANGE:` - Breaking changes → **Major version bump** (v1.2.0 → v2.0.0)
- Patch version bump (v1.2.0 → v1.2.1)
    - `fix:` - Bug fix
    - `docs:` - Documentation changes
    - `chore:` - Maintenance tasks (dependencies, build config, tooling)
    - `refactor:` - Code restructuring without behavior changes
    - `test:` - Test updates
    - `style:` - Formatting and whitespace
    - `ci:` - CI/CD configuration changes
    - `perf:` - Performance improvements
    - `build:` - Dependabot commits
    - `no conventional commits` - text without specifying any of above


### Commit Message Examples

```bash
# Patch release (v1.2.3 → v1.2.4)
git commit -m "fix: resolve upload timeout issue"

# Minor release (v1.2.3 → v1.3.0)
git commit -m "feat: add retry logic for failed uploads"

# Major release (v1.2.3 → v2.0.0)
git commit -m "feat: redesign upload API

BREAKING CHANGE: Upload() signature changed to return structured error"

# No release
git commit -m "docs: update Azure Blob Storage usage examples"
git commit -m "chore: upgrade dependencies"