### PR TITLE
Implement multipart copy for s3

### DIFF
--- a/.github/scripts/s3/run-integration-aws-iam.sh
+++ b/.github/scripts/s3/run-integration-aws-iam.sh
@@ -49,7 +49,8 @@ pushd "${repo_root}" > /dev/null
   --function-name "${lambda_function_name}" \
   --zip-file fileb://payload.zip \
   --role "${iam_role_arn}" \
-  --timeout 300 \
+  --timeout 600 \
+  --memory-size 512 \
   --handler lambda_function.test_runner_handler \
   --runtime python3.9
 
@@ -58,8 +59,8 @@ pushd "${repo_root}" > /dev/null
     tries=0
     get_function_status_command="aws lambda get-function --region ${region_name} --function-name ${lambda_function_name}"
     function_status=$(${get_function_status_command})
-    while [[ ( $(echo "${function_status}"  | jq -r ".Configuration.State") != "Active" ) && ( $tries -ne 5 ) ]] ; do
-      sleep 2
+    while [[ ( $(echo "${function_status}"  | jq -r ".Configuration.State") != "Active" ) && ( $tries -ne 15 ) ]] ; do
+      sleep 3
       echo "Checking for function readiness; attempt: $tries"
       tries=$((tries + 1))
       function_status=$(${get_function_status_command})

--- a/s3/README.md
+++ b/s3/README.md
@@ -12,23 +12,25 @@ The S3 client requires a JSON configuration file with the following structure:
 
 ``` json
 {
-  "bucket_name":            "<string> (required)",
-  "credentials_source":     "<string> [static|env_or_profile|none]",
-  "access_key_id":          "<string> (required if credentials_source = 'static')",
-  "secret_access_key":      "<string> (required if credentials_source = 'static')",
-  "region":                 "<string> (optional - default: 'us-east-1')",
-  "host":                   "<string> (optional)",
-  "port":                   <int> (optional),
-  "ssl_verify_peer":        <bool> (optional - default: true),
-  "use_ssl":                <bool> (optional - default: true),
-  "signature_version":      "<string> (optional)",
-  "server_side_encryption": "<string> (optional)",
-  "sse_kms_key_id":         "<string> (optional)",
-  "multipart_upload":       <bool> (optional - default: true),
-  "download_concurrency":   <int> (optional - default: 5),
-  "download_part_size":     <int64> (optional - default: 5242880), # 5 MB
-  "upload_concurrency":     <int> (optional - default: 5),
-  "upload_part_size":       <int64> (optional - default: 5242880) # 5 MB
+  "bucket_name":                "<string> (required)",
+  "credentials_source":         "<string> [static|env_or_profile|none]",
+  "access_key_id":              "<string> (required if credentials_source = 'static')",
+  "secret_access_key":          "<string> (required if credentials_source = 'static')",
+  "region":                     "<string> (optional - default: 'us-east-1')",
+  "host":                       "<string> (optional)",
+  "port":                       <int> (optional),
+  "ssl_verify_peer":            <bool> (optional - default: true),
+  "use_ssl":                    <bool> (optional - default: true),
+  "signature_version":          "<string> (optional)",
+  "server_side_encryption":     "<string> (optional)",
+  "sse_kms_key_id":             "<string> (optional)",
+  "multipart_upload":           <bool> (optional - default: true),
+  "download_concurrency":       <int> (optional - default: 5),
+  "download_part_size":         <int64> (optional - default: 5242880), # 5 MB
+  "upload_concurrency":         <int> (optional - default: 5),
+  "upload_part_size":           <int64> (optional - default: 5242880) # 5 MB
+  "multipart_copy_threshold":   <int64> (optional - default: 5368709120) # default 5 GB
+  "multipart_copy_part_size":   <int64> (optional - default: 104857600) # default 100 MB - must be at least 5 MB
 }
 ```
 > Note: **multipart_upload** is not supported by Google - it's automatically set to false by parsing the provided 'host'

--- a/s3/integration/aws_iam_role_test.go
+++ b/s3/integration/aws_iam_role_test.go
@@ -62,5 +62,9 @@ var _ = Describe("Testing inside an AWS compute resource with an IAM role", func
 			func(cfg *config.S3Cli) { integration.AssertDeleteNonexistentWorks(s3CLIPath, cfg) },
 			configurations,
 		)
+		DescribeTable("Multipart copy works with low threshold",
+			func(cfg *config.S3Cli) { integration.AssertMultipartCopyWorks(s3CLIPath, cfg) },
+			configurations,
+		)
 	})
 })

--- a/s3/integration/aws_us_east_test.go
+++ b/s3/integration/aws_us_east_test.go
@@ -62,5 +62,9 @@ var _ = Describe("Testing only in us-east-1", func() {
 			func(cfg *config.S3Cli) { integration.AssertDeleteNonexistentWorks(s3CLIPath, cfg) },
 			configurations,
 		)
+		DescribeTable("Multipart copy works with low threshold",
+			func(cfg *config.S3Cli) { integration.AssertMultipartCopyWorks(s3CLIPath, cfg) },
+			configurations,
+		)
 	})
 })

--- a/s3/integration/general_aws_test.go
+++ b/s3/integration/general_aws_test.go
@@ -79,6 +79,10 @@ var _ = Describe("General testing for all AWS regions", func() {
 			func(cfg *config.S3Cli) { integration.AssertOnSignedURLs(s3CLIPath, cfg) },
 			configurations,
 		)
+		DescribeTable("Multipart copy works with low threshold",
+			func(cfg *config.S3Cli) { integration.AssertMultipartCopyWorks(s3CLIPath, cfg) },
+			configurations,
+		)
 
 		configurations = []TableEntry{
 			Entry("with encryption", &config.S3Cli{

--- a/s3/integration/s3_compatible_test.go
+++ b/s3/integration/s3_compatible_test.go
@@ -89,5 +89,9 @@ var _ = Describe("Testing in any non-AWS, S3 compatible storage service", func()
 			func(cfg *config.S3Cli) { integration.AssertOnSignedURLs(s3CLIPath, cfg) },
 			configurations,
 		)
+		DescribeTable("Multipart copy works with low threshold",
+			func(cfg *config.S3Cli) { integration.AssertMultipartCopyWorks(s3CLIPath, cfg) },
+			configurations,
+		)
 	})
 })


### PR DESCRIPTION
AWS S3 requires multipart copy for files larger than 5GB. Other providers might have different levels thus this value is configurable.