### PR TITLE
File size increased for flaky test

### DIFF
--- a/azurebs/integration/assertions.go
+++ b/azurebs/integration/assertions.go
@@ -62,7 +62,7 @@ func AssertPutTimesOut(cliPath string, cfg *config.AZStorageConfig) {
 	defer os.Remove(configPath) //nolint:errcheck
 
 	const mb = 1024 * 1024
-	big := bytes.Repeat([]byte("x"), 250*mb)
+	big := bytes.Repeat([]byte("x"), 1000*mb)
 	content := MakeContentFile(string(big))
 	defer os.Remove(content) //nolint:errcheck
 	blob := GenerateRandomString()


### PR DESCRIPTION
A test case for testing upload timeout for azurebs might fail time to time depending on networks and infra. So we increased the size of file to make it not possible to upload in 1sec and expecting it to fail.