### PR TITLE
Auto-merge of dependabot PRs

### DIFF
--- a/.github/workflows/alioss-integration.yml
+++ b/.github/workflows/alioss-integration.yml
@@ -3,11 +3,6 @@ name: Alioss Integration Tests
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-    - ".github/workflows/alioss-integration.yml"
-    - "alioss/**"
-    - "go.mod"
-    - "go.sum"
   push:
     branches:
       - main

--- a/.github/workflows/alioss-integration.yml
+++ b/.github/workflows/alioss-integration.yml
@@ -2,6 +2,11 @@ name: Alioss Integration Tests
 
 on:
   workflow_dispatch:
+    inputs:
+      pr_ref:
+        description: 'SHA of the PR head commit (for fork PRs)'
+        required: false
+        default: ''
   pull_request:
   push:
     branches:
@@ -23,6 +28,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.pr_ref || github.sha }}
       - name: Set up Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/azurebs-integration.yml
+++ b/.github/workflows/azurebs-integration.yml
@@ -3,11 +3,6 @@ name: Azurebs Integration Tests
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-    - ".github/workflows/azurebs-integration.yml"
-    - "azurebs/**"
-    - "go.mod"
-    - "go.sum"
   push:
     branches:
       - main

--- a/.github/workflows/azurebs-integration.yml
+++ b/.github/workflows/azurebs-integration.yml
@@ -2,6 +2,11 @@ name: Azurebs Integration Tests
 
 on:
   workflow_dispatch:
+    inputs:
+      pr_ref:
+        description: 'SHA of the PR head commit (for fork PRs)'
+        required: false
+        default: ''
   pull_request:
   push:
     branches:
@@ -23,6 +28,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.pr_ref || github.sha }}
       - name: Set up Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/dav-integration.yml
+++ b/.github/workflows/dav-integration.yml
@@ -2,6 +2,11 @@ name: DAV Integration Tests
 
 on:
   workflow_dispatch:
+    inputs:
+      pr_ref:
+        description: 'SHA of the PR head commit (for fork PRs)'
+        required: false
+        default: ''
   pull_request:
   push:
     branches:
@@ -23,6 +28,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.pr_ref || github.sha }}
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/dav-integration.yml
+++ b/.github/workflows/dav-integration.yml
@@ -3,11 +3,6 @@ name: DAV Integration Tests
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-    - ".github/workflows/dav-integration.yml"
-    - "dav/**"
-    - "go.mod"
-    - "go.sum"
   push:
     branches:
       - main

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,15 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --rebase "${{ github.event.pull_request.number }}"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: github.actor == 'dependabot[bot]'
     steps:
       - name: Enable auto-merge
         run: gh pr merge --auto --rebase "${{ github.event.pull_request.number }}"

--- a/.github/workflows/fork-integration-trigger.yml
+++ b/.github/workflows/fork-integration-trigger.yml
@@ -1,0 +1,48 @@
+name: Trigger integration tests for fork PRs
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  trigger:
+    name: Trigger integration tests
+    runs-on: ubuntu-latest
+    if: |
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '/run-integration')
+    steps:
+      - name: Check commenter has write permission
+        run: |
+          permission=$(gh api repos/$GITHUB_REPOSITORY/collaborators/${{ github.actor }}/permission --jq '.permission')
+          if [[ "$permission" != "write" && "$permission" != "admin" ]]; then
+            echo "${{ github.actor }} does not have write permission (got: $permission)"
+            exit 1
+          fi
+
+      - name: Get PR head SHA and check for fork
+        id: pr
+        run: |
+          pr=$(gh pr view ${{ github.event.issue.number }} --json headRefOid,isCrossRepository)
+          read -r ref is_fork < <(echo "$pr" | jq -r '[.headRefOid, (.isCrossRepository | tostring)] | @tsv')
+          if [[ "$is_fork" == "false" ]]; then
+            echo "This command is only needed for fork PRs. Integration tests run automatically for PRs from this repository."
+            exit 1
+          fi
+          echo "ref=$ref" >> $GITHUB_OUTPUT
+
+      - name: Add reaction to comment
+        run: |
+          gh api --method POST \
+            repos/$GITHUB_REPOSITORY/issues/comments/${{ github.event.comment.id }}/reactions \
+            -f content=rocket
+
+      - name: Trigger integration tests
+        run: |
+          for workflow in s3-integration.yml gcs-integration.yml alioss-integration.yml azurebs-integration.yml dav-integration.yml; do
+            gh workflow run "$workflow" --ref ${{ github.event.repository.default_branch }} -f pr_ref=${{ steps.pr.outputs.ref }} &
+          done
+          wait

--- a/.github/workflows/gcs-integration.yml
+++ b/.github/workflows/gcs-integration.yml
@@ -3,11 +3,6 @@ name: GCS Integration Tests
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-    - ".github/workflows/gcs-integration.yml"
-    - "gcs/**"
-    - "go.mod"
-    - "go.sum"
   push:
     branches:
     - "main"

--- a/.github/workflows/gcs-integration.yml
+++ b/.github/workflows/gcs-integration.yml
@@ -2,6 +2,11 @@ name: GCS Integration Tests
 
 on:
   workflow_dispatch:
+    inputs:
+      pr_ref:
+        description: 'SHA of the PR head commit (for fork PRs)'
+        required: false
+        default: ''
   pull_request:
   push:
     branches:
@@ -22,7 +27,9 @@ jobs:
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7     
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.pr_ref || github.sha }}
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -57,7 +64,9 @@ jobs:
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7      
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.pr_ref || github.sha }} 
       - name: Set up Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/s3-integration.yml
+++ b/.github/workflows/s3-integration.yml
@@ -2,6 +2,11 @@ name: S3 Integration Tests
 
 on:
   workflow_dispatch:
+    inputs:
+      pr_ref:
+        description: 'SHA of the PR head commit (for fork PRs)'
+        required: false
+        default: ''
   pull_request:
   push:
     branches:
@@ -27,6 +32,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.pr_ref || github.sha }}
 
       - name: Set up test environment
         uses: ./.github/actions/go-test-bootstrap
@@ -113,6 +120,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.pr_ref || github.sha }}
 
       - name: Set up test environment
         uses: ./.github/actions/go-test-bootstrap
@@ -156,6 +165,8 @@ jobs:
    steps:
      - name: Checkout code
        uses: actions/checkout@v7
+       with:
+         ref: ${{ inputs.pr_ref || github.sha }}
 
      - name: Set up test environment
        uses: ./.github/actions/go-test-bootstrap

--- a/.github/workflows/s3-integration.yml
+++ b/.github/workflows/s3-integration.yml
@@ -3,11 +3,6 @@ name: S3 Integration Tests
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-    - ".github/workflows/s3-integration.yml"
-    - "s3/**"
-    - "go.mod"
-    - "go.sum"
   push:
     branches:
       - main


### PR DESCRIPTION
- uses PR auto-merge feature (must be enabled on repo)
- requires required status checks in branch protection (extra PR)
- all actions configured as status checks must run unconditionally on a PR (i.e. no path restrictions)
- fork PRs: approvers can trigger integration tests by /run-integration comment on PR AFTER reviewing the PR, the integration tests run then in the context of the approver (i.e. with secrets)