### PR TITLE
Scope dav recursive list and delete to the requested prefix

### DIFF
--- a/dav/client/storage_client.go
+++ b/dav/client/storage_client.go
@@ -336,8 +336,32 @@ func (c *storageClient) List(prefix string) ([]string, error) {
 	if !strings.HasPrefix(rootURL.Path, "/") {
 		rootURL.Path = "/" + rootURL.Path
 	}
+	endpointPath := rootURL.Path
 
-	return c.listRecursive(rootURL.String(), rootURL.Path, prefix)
+	// Start the walk at the deepest directory the prefix fully names, so the
+	// traversal is bounded by the prefix's subtree instead of the whole store.
+	// Blob IDs are matched as string prefixes, so only the portion of the
+	// prefix up to its last "/" is guaranteed to be a directory. The trailing
+	// slash marks the URL as a collection, matching the slash-terminated hrefs
+	// the recursion follows and avoiding directory redirects from servers that
+	// insist on the canonical form.
+	if dir := prefixDir(prefix); dir != "" {
+		rootURL.Path = path.Join(rootURL.Path, dir) + "/"
+	}
+
+	return c.listRecursive(rootURL.String(), endpointPath, prefix)
+}
+
+// prefixDir returns the deepest directory a blob-ID prefix fully names, or ""
+// when the prefix does not name one ("" or a single path segment) or would
+// escape the endpoint through ".." segments, in which case the walk starts at
+// the endpoint root as it always did.
+func prefixDir(prefix string) string {
+	dir := path.Dir(strings.TrimPrefix(prefix, "/"))
+	if dir == "." || dir == "/" || dir == ".." || strings.HasPrefix(dir, "../") {
+		return ""
+	}
+	return dir
 }
 
 func (c *storageClient) listRecursive(dirURL, endpointPath, prefix string) ([]string, error) {
@@ -395,6 +419,9 @@ func (c *storageClient) listRecursive(dirURL, endpointPath, prefix string) ([]st
 		}
 
 		if response.isCollection() {
+			if !collectionMayContainPrefix(response.Href, endpointPath, prefix) {
+				continue
+			}
 			subURL := hrefURL.String()
 			if !hrefURL.IsAbs() {
 				subURL = parsedDirURL.ResolveReference(hrefURL).String()
@@ -418,6 +445,24 @@ func (c *storageClient) listRecursive(dirURL, endpointPath, prefix string) ([]st
 	}
 
 	return blobs, nil
+}
+
+// collectionMayContainPrefix reports whether a collection can hold blob IDs
+// matching the prefix. Every blob under a collection with relative path rel
+// has an ID starting with rel+"/", so the collection is worth descending into
+// only when rel+"/" and the prefix are string prefixes of one another.
+func collectionMayContainPrefix(href, endpointPath, prefix string) bool {
+	if prefix == "" {
+		return true
+	}
+	rel, err := blobIDFromHref(href, endpointPath)
+	if err != nil {
+		// Can't map the href to a relative path; descend rather than risk
+		// skipping blobs.
+		return true
+	}
+	rel = strings.TrimSuffix(rel, "/") + "/"
+	return strings.HasPrefix(prefix, rel) || strings.HasPrefix(rel, prefix)
 }
 
 // blobIDFromHref extracts the blob ID from a WebDAV href

--- a/dav/client/storage_client_list_test.go
+++ b/dav/client/storage_client_list_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -121,21 +121,9 @@ func newTestStorageClient(t *testing.T, store *fakeDavServer) (*storageClient, f
 }
 
 func sorted(in []string) []string {
-	out := append([]string{}, in...)
-	sort.Strings(out)
+	out := slices.Clone(in)
+	slices.Sort(out)
 	return out
-}
-
-func equalStrings(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }
 
 func TestListScopesWalkToPrefix(t *testing.T) {
@@ -149,12 +137,12 @@ func TestListScopesWalkToPrefix(t *testing.T) {
 	}
 
 	wantBlobs := []string{"ab/cd/abcd-target-guid-file", "ab/cd/abcd-target-guid/cflinuxfs4"}
-	if !equalStrings(sorted(blobs), wantBlobs) {
+	if !slices.Equal(sorted(blobs), wantBlobs) {
 		t.Fatalf("unexpected blobs: %v, want %v", sorted(blobs), wantBlobs)
 	}
 
 	wantPropfinds := []string{"ab/cd", "ab/cd/abcd-target-guid"}
-	if !equalStrings(sorted(store.propfinds), wantPropfinds) {
+	if !slices.Equal(sorted(store.propfinds), wantPropfinds) {
 		t.Fatalf("walk was not scoped to the prefix: PROPFINDs hit %v, want %v", sorted(store.propfinds), wantPropfinds)
 	}
 }
@@ -177,7 +165,7 @@ func TestListEmptyPrefixWalksWholeStore(t *testing.T) {
 		"ab/zz/abzz-unrelated",
 		"zz/yy/zzyy-other",
 	}
-	if !equalStrings(sorted(blobs), wantBlobs) {
+	if !slices.Equal(sorted(blobs), wantBlobs) {
 		t.Fatalf("unexpected blobs: %v, want %v", sorted(blobs), wantBlobs)
 	}
 }
@@ -212,7 +200,7 @@ func TestListSingleSegmentPrefixPrunesSiblings(t *testing.T) {
 		"ab/cd/abcd-unrelated",
 		"ab/zz/abzz-unrelated",
 	}
-	if !equalStrings(sorted(blobs), wantBlobs) {
+	if !slices.Equal(sorted(blobs), wantBlobs) {
 		t.Fatalf("unexpected blobs: %v, want %v", sorted(blobs), wantBlobs)
 	}
 
@@ -233,12 +221,12 @@ func TestDeleteRecursiveDeletesOnlyPrefixedBlobs(t *testing.T) {
 	}
 
 	wantDeletes := []string{"ab/cd/abcd-target-guid-file", "ab/cd/abcd-target-guid/cflinuxfs4"}
-	if !equalStrings(sorted(store.deletes), wantDeletes) {
+	if !slices.Equal(sorted(store.deletes), wantDeletes) {
 		t.Fatalf("unexpected deletes: %v, want %v", sorted(store.deletes), wantDeletes)
 	}
 
 	wantPropfinds := []string{"ab/cd", "ab/cd/abcd-target-guid"}
-	if !equalStrings(sorted(store.propfinds), wantPropfinds) {
+	if !slices.Equal(sorted(store.propfinds), wantPropfinds) {
 		t.Fatalf("walk was not scoped to the prefix: PROPFINDs hit %v, want %v", sorted(store.propfinds), wantPropfinds)
 	}
 }

--- a/dav/client/storage_client_list_test.go
+++ b/dav/client/storage_client_list_test.go
@@ -1,0 +1,327 @@
+package client
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	davconf "github.com/cloudfoundry/storage-cli/dav/config"
+)
+
+// fakeDavServer serves a static directory tree over PROPFIND/DELETE and
+// records which paths were hit, so tests can assert how far a walk went.
+type fakeDavServer struct {
+	mu        sync.Mutex
+	propfinds []string
+	deletes   []string
+
+	// dirs maps a directory path (relative to the endpoint, "" for the
+	// root) to its child entries.
+	dirs map[string][]fakeEntry
+}
+
+type fakeEntry struct {
+	name  string
+	isDir bool
+}
+
+func (s *fakeDavServer) handler(endpointPath string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		rel := strings.Trim(strings.TrimPrefix(r.URL.Path, endpointPath), "/")
+
+		switch r.Method {
+		case "PROPFIND":
+			s.mu.Lock()
+			s.propfinds = append(s.propfinds, rel)
+			s.mu.Unlock()
+
+			children, ok := s.dirs[rel]
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+
+			var b strings.Builder
+			b.WriteString(`<?xml version="1.0"?><D:multistatus xmlns:D="DAV:">`)
+			writeResponse := func(href string, isDir bool) {
+				resourceType := ""
+				if isDir {
+					resourceType = "<D:collection/>"
+				}
+				fmt.Fprintf(&b,
+					`<D:response><D:href>%s</D:href><D:propstat><D:prop><D:resourcetype>%s</D:resourcetype></D:prop></D:propstat></D:response>`,
+					href, resourceType)
+			}
+
+			self := endpointPath + "/"
+			if rel != "" {
+				self = endpointPath + "/" + rel + "/"
+			}
+			writeResponse(self, true)
+			for _, child := range children {
+				href := endpointPath + "/" + child.name
+				if rel != "" {
+					href = endpointPath + "/" + rel + "/" + child.name
+				}
+				if child.isDir {
+					href += "/"
+				}
+				writeResponse(href, child.isDir)
+			}
+			b.WriteString(`</D:multistatus>`)
+
+			w.Header().Set("Content-Type", "application/xml")
+			w.WriteHeader(http.StatusMultiStatus)
+			w.Write([]byte(b.String())) //nolint:errcheck
+
+		case "DELETE":
+			s.mu.Lock()
+			s.deletes = append(s.deletes, rel)
+			s.mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}
+}
+
+// newPartitionedStore models a CC-style blobstore: two levels of partition
+// directories with blobs at the leaves, plus sibling partitions that a
+// correctly scoped walk must never touch.
+func newPartitionedStore() *fakeDavServer {
+	return &fakeDavServer{
+		dirs: map[string][]fakeEntry{
+			"": {
+				{name: "aa", isDir: true},
+				{name: "ab", isDir: true},
+				{name: "zz", isDir: true},
+			},
+			"aa":                     {{name: "bb", isDir: true}},
+			"aa/bb":                  {{name: "aabb-other-guid", isDir: false}},
+			"ab":                     {{name: "cd", isDir: true}, {name: "zz", isDir: true}},
+			"ab/zz":                  {{name: "abzz-unrelated", isDir: false}},
+			"ab/cd":                  {{name: "abcd-target-guid", isDir: true}, {name: "abcd-target-guid-file", isDir: false}, {name: "abcd-unrelated", isDir: false}},
+			"ab/cd/abcd-target-guid": {{name: "cflinuxfs4", isDir: false}},
+			"zz":                     {{name: "yy", isDir: true}},
+			"zz/yy":                  {{name: "zzyy-other", isDir: false}},
+		},
+	}
+}
+
+func newTestStorageClient(t *testing.T, store *fakeDavServer) (*storageClient, func()) {
+	t.Helper()
+	server := httptest.NewServer(store.handler("/dav"))
+	c := NewStorageClient(davconf.Config{Endpoint: server.URL + "/dav"}, http.DefaultClient)
+	return c.(*storageClient), server.Close
+}
+
+func sorted(in []string) []string {
+	out := append([]string{}, in...)
+	sort.Strings(out)
+	return out
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestListScopesWalkToPrefix(t *testing.T) {
+	store := newPartitionedStore()
+	c, cleanup := newTestStorageClient(t, store)
+	defer cleanup()
+
+	blobs, err := c.List("ab/cd/abcd-target-guid")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wantBlobs := []string{"ab/cd/abcd-target-guid-file", "ab/cd/abcd-target-guid/cflinuxfs4"}
+	if !equalStrings(sorted(blobs), wantBlobs) {
+		t.Fatalf("unexpected blobs: %v, want %v", sorted(blobs), wantBlobs)
+	}
+
+	wantPropfinds := []string{"ab/cd", "ab/cd/abcd-target-guid"}
+	if !equalStrings(sorted(store.propfinds), wantPropfinds) {
+		t.Fatalf("walk was not scoped to the prefix: PROPFINDs hit %v, want %v", sorted(store.propfinds), wantPropfinds)
+	}
+}
+
+func TestListEmptyPrefixWalksWholeStore(t *testing.T) {
+	store := newPartitionedStore()
+	c, cleanup := newTestStorageClient(t, store)
+	defer cleanup()
+
+	blobs, err := c.List("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wantBlobs := []string{
+		"aa/bb/aabb-other-guid",
+		"ab/cd/abcd-target-guid-file",
+		"ab/cd/abcd-target-guid/cflinuxfs4",
+		"ab/cd/abcd-unrelated",
+		"ab/zz/abzz-unrelated",
+		"zz/yy/zzyy-other",
+	}
+	if !equalStrings(sorted(blobs), wantBlobs) {
+		t.Fatalf("unexpected blobs: %v, want %v", sorted(blobs), wantBlobs)
+	}
+}
+
+func TestListMissingPrefixDirectoryReturnsEmpty(t *testing.T) {
+	store := newPartitionedStore()
+	c, cleanup := newTestStorageClient(t, store)
+	defer cleanup()
+
+	blobs, err := c.List("no/such/prefix")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(blobs) != 0 {
+		t.Fatalf("expected no blobs, got %v", blobs)
+	}
+}
+
+func TestListSingleSegmentPrefixPrunesSiblings(t *testing.T) {
+	store := newPartitionedStore()
+	c, cleanup := newTestStorageClient(t, store)
+	defer cleanup()
+
+	blobs, err := c.List("ab")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wantBlobs := []string{
+		"ab/cd/abcd-target-guid-file",
+		"ab/cd/abcd-target-guid/cflinuxfs4",
+		"ab/cd/abcd-unrelated",
+		"ab/zz/abzz-unrelated",
+	}
+	if !equalStrings(sorted(blobs), wantBlobs) {
+		t.Fatalf("unexpected blobs: %v, want %v", sorted(blobs), wantBlobs)
+	}
+
+	for _, p := range store.propfinds {
+		if strings.HasPrefix(p, "aa") || strings.HasPrefix(p, "zz") {
+			t.Fatalf("walk descended into sibling partition %q; PROPFINDs: %v", p, store.propfinds)
+		}
+	}
+}
+
+func TestDeleteRecursiveDeletesOnlyPrefixedBlobs(t *testing.T) {
+	store := newPartitionedStore()
+	c, cleanup := newTestStorageClient(t, store)
+	defer cleanup()
+
+	if err := c.DeleteRecursive("ab/cd/abcd-target-guid"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wantDeletes := []string{"ab/cd/abcd-target-guid-file", "ab/cd/abcd-target-guid/cflinuxfs4"}
+	if !equalStrings(sorted(store.deletes), wantDeletes) {
+		t.Fatalf("unexpected deletes: %v, want %v", sorted(store.deletes), wantDeletes)
+	}
+
+	wantPropfinds := []string{"ab/cd", "ab/cd/abcd-target-guid"}
+	if !equalStrings(sorted(store.propfinds), wantPropfinds) {
+		t.Fatalf("walk was not scoped to the prefix: PROPFINDs hit %v, want %v", sorted(store.propfinds), wantPropfinds)
+	}
+}
+
+func TestListEscapingPrefixStaysInsideEndpoint(t *testing.T) {
+	store := newPartitionedStore()
+	c, cleanup := newTestStorageClient(t, store)
+	defer cleanup()
+
+	for _, prefix := range []string{"../", "../../..", "../etc/passwd"} {
+		store.propfinds = nil
+
+		blobs, err := c.List(prefix)
+		if err != nil {
+			t.Fatalf("List(%q): unexpected error: %v", prefix, err)
+		}
+		if len(blobs) != 0 {
+			t.Fatalf("List(%q): expected no blobs, got %v", prefix, blobs)
+		}
+		for _, p := range store.propfinds {
+			if strings.Contains(p, "..") {
+				t.Fatalf("List(%q): PROPFIND escaped the endpoint: %v", prefix, store.propfinds)
+			}
+		}
+	}
+}
+
+func TestDeleteRecursiveMissingPrefixIsNoop(t *testing.T) {
+	store := newPartitionedStore()
+	c, cleanup := newTestStorageClient(t, store)
+	defer cleanup()
+
+	if err := c.DeleteRecursive("no/such/prefix"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(store.deletes) != 0 {
+		t.Fatalf("expected no deletes, got %v", store.deletes)
+	}
+}
+
+func TestPrefixDir(t *testing.T) {
+	cases := []struct {
+		prefix string
+		want   string
+	}{
+		{prefix: "", want: ""},
+		{prefix: "abc", want: ""},
+		{prefix: "ab/", want: "ab"},
+		{prefix: "ab/cd", want: "ab"},
+		{prefix: "ab/cd/", want: "ab/cd"},
+		{prefix: "ab/cd/guid", want: "ab/cd"},
+		{prefix: "/ab/cd/guid", want: "ab/cd"},
+		{prefix: "..", want: ""},
+		{prefix: "../", want: ""},
+		{prefix: "../etc", want: ""},
+		{prefix: "../../../etc", want: ""},
+		{prefix: "a/../../b", want: ""},
+		{prefix: "foo/../bar/x", want: "bar"},
+	}
+	for _, tc := range cases {
+		if got := prefixDir(tc.prefix); got != tc.want {
+			t.Errorf("prefixDir(%q) = %q, want %q", tc.prefix, got, tc.want)
+		}
+	}
+}
+
+func TestCollectionMayContainPrefix(t *testing.T) {
+	cases := []struct {
+		href   string
+		prefix string
+		want   bool
+	}{
+		{href: "/dav/ab/", prefix: "", want: true},
+		{href: "/dav/ab/", prefix: "ab/cd/guid", want: true},
+		{href: "/dav/ab/cd/", prefix: "ab/cd/guid", want: true},
+		{href: "/dav/ab/cd/guid-dir/", prefix: "ab/cd/guid", want: true},
+		{href: "/dav/ab/cd/other/", prefix: "ab/cd/guid", want: false},
+		{href: "/dav/aa/", prefix: "ab/cd/guid", want: false},
+		{href: "/dav/ab/zz/", prefix: "ab/cd/guid", want: false},
+	}
+	for _, tc := range cases {
+		if got := collectionMayContainPrefix(tc.href, "/dav", tc.prefix); got != tc.want {
+			t.Errorf("collectionMayContainPrefix(%q, %q) = %v, want %v", tc.href, tc.prefix, got, tc.want)
+		}
+	}
+}

--- a/dav/integration/assertions.go
+++ b/dav/integration/assertions.go
@@ -160,6 +160,64 @@ func AssertOnListDeleteLifecycle(cliPath string, cfg *config.Config) {
 	}
 }
 
+func AssertOnNestedListDeleteLifecycle(cliPath string, cfg *config.Config) {
+	guid := GenerateRandomString()
+	prefix := "ab/cd/" + guid
+
+	configPath := MakeConfigFile(cfg)
+	defer os.Remove(configPath) //nolint:errcheck
+
+	targets := []string{
+		prefix + "/droplet",
+		prefix + "-extra",
+	}
+	bystanders := []string{
+		"ab/cd/" + GenerateRandomString(),
+		"zz/yy/" + GenerateRandomString(),
+	}
+
+	var contentFiles []string
+	defer func() {
+		for _, f := range contentFiles {
+			os.Remove(f) //nolint:errcheck
+		}
+	}()
+
+	for _, blobName := range append(append([]string{}, targets...), bystanders...) {
+		contentFile := MakeContentFile(GenerateRandomString())
+		contentFiles = append(contentFiles, contentFile)
+		session, err := RunCli(cliPath, configPath, storageType, "put", contentFile, blobName)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(session.ExitCode()).To(BeZero())
+	}
+
+	session, err := RunCli(cliPath, configPath, storageType, "list", prefix)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(session.ExitCode()).To(BeZero())
+	for _, blobName := range targets {
+		Expect(session.Out.Contents()).To(ContainSubstring(blobName))
+	}
+	for _, blobName := range bystanders {
+		Expect(session.Out.Contents()).ToNot(ContainSubstring(blobName))
+	}
+
+	session, err = RunCli(cliPath, configPath, storageType, "delete-recursive", prefix)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(session.ExitCode()).To(BeZero())
+
+	for _, blobName := range targets {
+		session, err := RunCli(cliPath, configPath, storageType, "exists", blobName)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(session.ExitCode()).ToNot(BeZero())
+	}
+
+	for _, blobName := range bystanders {
+		session, err := RunCli(cliPath, configPath, storageType, "exists", blobName)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(session.ExitCode()).To(BeZero())
+	}
+}
+
 func AssertListNonexistentPrefixReturnsEmpty(cliPath string, cfg *config.Config) {
 	nonExistentPrefix := GenerateRandomString()
 

--- a/dav/integration/general_dav_test.go
+++ b/dav/integration/general_dav_test.go
@@ -61,6 +61,16 @@ var _ = Describe("General testing for DAV", func() {
 			integration.AssertOnListDeleteLifecycle(cliPath, cfg)
 		})
 
+		It("Blobstore list and delete-recursive lifecycle works with nested prefixes", func() {
+			cfg := &config.Config{
+				Endpoint: davEndpoint,
+				User:     davUser,
+				Password: davPassword,
+				TLS:      config.TLS{Cert: config.Cert{CA: davCA}},
+			}
+			integration.AssertOnNestedListDeleteLifecycle(cliPath, cfg)
+		})
+
 		It("Invoking `list` on non-existent prefix returns empty list", func() {
 			cfg := &config.Config{
 				Endpoint: davEndpoint,


### PR DESCRIPTION
Fixes #129

## Problem

The dav backend's `List(prefix)` starts its `Depth: 1` PROPFIND walk at the blobstore endpoint root and applies the prefix only when it reaches a leaf, so `DeleteRecursive` traverses the entire blobstore to delete one prefix. Against a production-sized WebDAV blobstore, where keys are partitioned into two-character directories, that is thousands of PROPFIND round trips per delete. Cloud Controller calls `delete-recursive` to clear an app's buildpack cache on every `cf delete -r`, and the walk does not finish before the operation times out. The s3 backend already scopes the same operation by passing the prefix to the server.

## Fix

Two changes in `dav/client/storage_client.go`, both affecting only which requests are made, not what is returned:

- `List` now roots the walk at the deepest directory the prefix fully names — the portion of the prefix up to its last `/`, computed by the new `prefixDir` helper. Blob IDs are matched as string prefixes rather than directory paths, so only that portion is guaranteed to be a directory; the final segment may match both a file (`ab/cd/guid-file`) and a directory (`ab/cd/guid/`), and starting one level up keeps both reachable. For Cloud Controller's partitioned keys (`ab/cd/<guid>`), the walk starts at `ab/cd` and a recursive delete becomes two PROPFINDs instead of a whole-store traversal.

- `listRecursive` now prunes subcollections that cannot contain matching blob IDs, via the new `collectionMayContainPrefix` helper: every blob under a collection with relative path `rel` has an ID starting with `rel + "/"`, so the walk descends only when `rel + "/"` and the prefix are string prefixes of one another. This bounds single-segment prefixes (which name no directory) and keeps the walk narrow below the starting point.

Two details of the starting URL:

- `prefixDir` rejects directories that would escape the endpoint through `..` segments (`path.Dir` cleans the path, so `../etc` and `a/../../b` are caught). Such prefixes fall back to the endpoint-root walk, exactly as before — they can never match a blob ID, so the result stays empty, and no request is ever issued outside the configured endpoint path.
- The starting URL is slash-terminated, marking it as a collection. That matches the slash-terminated hrefs the recursion already follows, and avoids directory redirects from servers that insist on the canonical form (Go's HTTP client would replay a redirected PROPFIND as a GET).

Observable behavior is unchanged: the leaf filter is untouched, `List("")` still walks the whole store, and a prefix whose directory does not exist still yields an empty list (the existing 404-on-PROPFIND handling), which `DeleteRecursive` already treats as a no-op.

## Testing

- New unit tests in `dav/client/storage_client_list_test.go` run `List` and `DeleteRecursive` against an httptest WebDAV fake that records every PROPFIND and DELETE path, and assert both the returned/deleted blob sets and the exact set of directories the walk touched — e.g. deleting `ab/cd/<guid>` PROPFINDs only `ab/cd` and `ab/cd/<guid>`, and never enters sibling partitions.
- A regression test pins the empty-prefix case to the full-store walk and the complete blob list.
- Table tests cover `prefixDir` and `collectionMayContainPrefix` edge cases (empty, single-segment, trailing-slash, leading-slash, and `..`-containing prefixes), and a dedicated test asserts that escaping prefixes never produce a PROPFIND outside the endpoint path.
- A new dav integration spec exercises the scoped walk against the real Dockerized nginx WebDAV server with multi-segment partitioned keys (`ab/cd/<id>`): it puts blobs under the prefix plus bystanders in sibling partitions, then verifies `list` and `delete-recursive` touch only the prefixed blobs. The existing integration prefixes are all single-segment, which never exercise the deeper starting URL.
- `go build ./...`, `go vet ./...`, `go test ./dav/...` (unit and Docker integration, 8 of 8 specs), and `golangci-lint run ./dav/...` all pass. The gcs/azurebs/s3 integration suites need live cloud credentials and were not run.
