### PR TITLE
Report IT status on fork PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,6 +1,8 @@
 name: Dependabot auto-merge
 
-on: pull_request
+on:
+  pull_request:
+    types: [opened]
 
 permissions:
   contents: write

--- a/.github/workflows/fork-integration-status-reporter.yml
+++ b/.github/workflows/fork-integration-status-reporter.yml
@@ -1,0 +1,52 @@
+name: Report integration test results for fork PRs
+
+on:
+  workflow_run:
+    workflows:
+      - "S3 Integration Tests"
+      - "GCS Integration Tests"
+      - "Alioss Integration Tests"
+      - "Azurebs Integration Tests"
+      - "DAV Integration Tests"
+    types: [completed]
+
+permissions:
+  statuses: write
+
+env:
+  GH_TOKEN: ${{ github.token }}
+
+jobs:
+  report:
+    name: Report status
+    runs-on: ubuntu-latest
+    # Only fork-triggered runs use workflow_dispatch; skip push/pull_request runs entirely
+    if: github.event.workflow_run.event == 'workflow_dispatch'
+    steps:
+      - name: Get pr_ref from triggering run
+        id: inputs
+        run: |
+          pr_ref=$(gh run view ${{ github.event.workflow_run.id }} \
+            --repo "$GITHUB_REPOSITORY" --json inputs \
+            --jq '.inputs.pr_ref // empty')
+          echo "pr_ref=$pr_ref" >> $GITHUB_OUTPUT
+
+      - name: Post commit status per job
+        if: steps.inputs.outputs.pr_ref != ''
+        run: |
+          pr_ref="${{ steps.inputs.outputs.pr_ref }}"
+          gh run view ${{ github.event.workflow_run.id }} \
+            --repo "$GITHUB_REPOSITORY" --json jobs \
+            --jq '.jobs[] | [.name, .conclusion, .url] | @tsv' \
+          | while IFS=$'\t' read -r name conclusion url; do
+            case "$conclusion" in
+              success)   state="success" ;;
+              cancelled) state="error" ;;
+              *)         state="failure" ;;
+            esac
+            gh api --method POST "repos/$GITHUB_REPOSITORY/statuses/$pr_ref" \
+              -f state="$state" \
+              -f context="$name" \
+              -f target_url="$url" \
+              -f description="$conclusion"
+          done

--- a/.github/workflows/fork-integration-trigger.yml
+++ b/.github/workflows/fork-integration-trigger.yml
@@ -46,6 +46,7 @@ jobs:
 
       - name: Trigger integration tests
         run: |
+          # run all integration test workflows in context of main branch, passing the PR head SHA as an input
           for workflow in s3-integration.yml gcs-integration.yml alioss-integration.yml azurebs-integration.yml dav-integration.yml; do
             gh workflow run "$workflow" --repo "$GITHUB_REPOSITORY" --ref ${{ github.event.repository.default_branch }} -f pr_ref=${{ steps.pr.outputs.ref }} &
           done


### PR DESCRIPTION
- needs a separate workflow because the ITs run in the context of main and not on the PR (due to secrets)
- run dependabot-auto-merge only on newly opened PRs (not on every PR chanage)