### PR TITLE
chore: remove remove-trailing-checksum-workaround-gdch

### DIFF
--- a/s3/config/config.go
+++ b/s3/config/config.go
@@ -165,8 +165,6 @@ func NewFromReader(reader io.Reader) (S3Cli, error) {
 		c.configureAlicloud()
 	case "google":
 		c.configureGoogle()
-	case "gdch":
-		c.configureGDCH()
 	default:
 		c.configureDefault()
 	}
@@ -218,12 +216,6 @@ func (c *S3Cli) configureGoogle() {
 	// Unlike AWS S3, GCS has no 5GB hard limit on single uploads, so math.MaxInt64 is safe here.
 	c.SingleUploadThreshold = math.MaxInt64
 	c.RequestChecksumCalculationEnabled = false
-}
-
-func (c *S3Cli) configureGDCH() {
-	c.RequestChecksumCalculationEnabled = false
-	c.ResponseChecksumCalculationEnabled = false
-	c.UploaderRequestChecksumCalculationEnabled = false
 }
 
 func (c *S3Cli) configureDefault() {

--- a/s3/config/endpoints.go
+++ b/s3/config/endpoints.go
@@ -9,7 +9,6 @@ var (
 		"aws":      regexp.MustCompile(`(^$|s3[-.]?(.*)\.amazonaws\.com(\.cn)?$)`),
 		"alicloud": regexp.MustCompile(`^oss-([a-z]+-[a-z]+(-[1-9])?)(-internal)?\.aliyuncs\.com$`),
 		"google":   regexp.MustCompile(`^storage\.googleapis\.com$`),
-		"gdch":     regexp.MustCompile(`objectstorage\..*`),
 	}
 )
 


### PR DESCRIPTION
## Summary:

GDCH underlying trailing checksum issue has been fixed, so the temporary configuration is no longer required.

## Test:
 I tested locally and was able to test the upload/download operations. 


```
./storage-cli -s s3 -c config.json -log-level debug put LICENSE LICENSE
{"time":"2026-07-29T10:16:21.083154+05:30","level":"DEBUG","msg":"s3 http request","method":"PUT","url":"https://objectstorage.dog.s.gpcdemolabs.com/a6c3am0-cc-buildpacks-lancer-maz/LICENSE?x-id=PutObject","host":"","request_content_length":11401,"duration_ms":1981,"extended_request_id":"12264729","status_code":200,"response_content_length":0,"request_id":"[3f481227-74cf-4993-9a93-c1f61b0c5027][382994c7-4241-445f-b2bf-073b2bde26c5]"}
{"time":"2026-07-29T10:16:21.084885+05:30","level":"INFO","msg":"Successfully uploaded file","location":"https://objectstorage.dog.s.gpcdemolabs.com/a6c3am0-cc-buildpacks-lancer-maz/LICENSE"}
```


```
./storage-cli -s s3 -c config.json -log-level debug get LICENSE LICENSEgg
{"time":"2026-07-29T10:17:30.907369+05:30","level":"DEBUG","msg":"s3 http request","method":"GET","url":"https://objectstorage.dog.s.gpcdemolabs.com/a6c3am0-cc-buildpacks-lancer-maz/LICENSE?x-id=GetObject","host":"","request_content_length":0,"duration_ms":1177,"response_content_length":11357,"request_id":"[9742bff7-e8a6-4b1b-98ad-3eae5a0a880b][7eea1639-8b99-4eba-9212-b869fcc07eba]","extended_request_id":"12844196","status_code":206}
```