### PR TITLE
Wait for bucket to become accessible after creation

### DIFF
--- a/s3/client/aws_s3_blobstore.go
+++ b/s3/client/aws_s3_blobstore.go
@@ -303,12 +303,20 @@ func (b *awsS3Client) EnsureStorageExists() error {
 		var alreadyExists *types.BucketAlreadyExists
 		if errors.As(err, &alreadyOwned) || errors.As(err, &alreadyExists) {
 			slog.Warn("Bucket got created by another process", "bucket", b.s3cliConfig.BucketName)
-			return nil
+		} else {
+			return fmt.Errorf("failed to create bucket: %w", err)
 		}
-		return fmt.Errorf("failed to create bucket: %w", err)
 	}
 
-	slog.Info("Bucket created successfully", "bucket", b.s3cliConfig.BucketName)
+	slog.Info("Bucket created, waiting for it to be accessible", "bucket", b.s3cliConfig.BucketName)
+	waiter := s3.NewBucketExistsWaiter(b.s3Client)
+	if waitErr := waiter.Wait(context.TODO(), &s3.HeadBucketInput{
+		Bucket: aws.String(b.s3cliConfig.BucketName),
+	}, 60*time.Second); waitErr != nil {
+		return fmt.Errorf("bucket created but did not become accessible: %w", waitErr)
+	}
+
+	slog.Info("Bucket is accessible", "bucket", b.s3cliConfig.BucketName)
 	return nil
 }
 


### PR DESCRIPTION
S3 bucket creation in non-us-east-1 regions is eventually consistent: CreateBucket can return success while HeadBucket still returns 404 for a short window. Use the SDK's BucketExistsWaiter after CreateBucket to poll until the bucket is accessible before returning, fixing the flaky ensure-storage-exists integration test in eu-central-1.

https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html#ConsistencyModel