### PR TITLE
Fixes for weekly release workflow

### DIFF
--- a/.github/workflows/release-cron.yml
+++ b/.github/workflows/release-cron.yml
@@ -79,42 +79,42 @@ jobs:
   integration-s3:
     name: Integration Tests - S3
     needs: [check, tests]
-    if: needs.check.outputs.should_release == 'true'
+    if: needs.tests.result == 'success'
     uses: ./.github/workflows/s3-integration.yml
     secrets: inherit
 
   integration-gcs:
     name: Integration Tests - GCS
     needs: [check, tests]
-    if: needs.check.outputs.should_release == 'true'
+    if: needs.tests.result == 'success'
     uses: ./.github/workflows/gcs-integration.yml
     secrets: inherit
 
   integration-azurebs:
     name: Integration Tests - Azure Blob Storage
     needs: [check, tests]
-    if: needs.check.outputs.should_release == 'true'
+    if: needs.tests.result == 'success'
     uses: ./.github/workflows/azurebs-integration.yml
     secrets: inherit
 
   integration-alioss:
     name: Integration Tests - Alibaba OSS
     needs: [check, tests]
-    if: needs.check.outputs.should_release == 'true'
+    if: needs.tests.result == 'success'
     uses: ./.github/workflows/alioss-integration.yml
     secrets: inherit
 
   integration-dav:
     name: Integration Tests - DAV
     needs: [check, tests]
-    if: needs.check.outputs.should_release == 'true'
+    if: needs.tests.result == 'success'
     uses: ./.github/workflows/dav-integration.yml
     secrets: inherit
 
   build-and-release:
     name: Build and Release
     needs: [check, tests, integration-s3, integration-gcs, integration-azurebs, integration-alioss, integration-dav]
-    if: needs.check.outputs.should_release == 'true'
+    if: needs.tests.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Into Source Code

--- a/.github/workflows/release-cron.yml
+++ b/.github/workflows/release-cron.yml
@@ -2,7 +2,7 @@ name: Release Cron
 
 on:
   schedule:
-    - cron: '0 8 * * 1'  # Every Monday at 08:00 UTC
+    - cron: '27 5 * * 2'  # Every Tuesday at 05:27 UTC
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -139,11 +139,13 @@ Dependabot PRs are merged automatically if they pass all required checks (tests 
 
 ### Automatic Weekly Releases
 
-The workflow [Release Cron](https://github.com/cloudfoundry/storage-cli/actions/workflows/release-cron.yml) builds an automatic release every Monday morning if there are changes on the `main` branch (e.g. version bumps).
+The workflow [Release Cron](https://github.com/cloudfoundry/storage-cli/actions/workflows/release-cron.yml) builds an automatic weekly patch release if there are changes on the `main` branch (e.g. version bumps).
 
 The workflow builds and tests storage-cli, runs the integration tests and creates a **draft release** that needs to be published manually. Note that only published storage-cli releases are picked up by [capi-release](https://github.com/cloudfoundry/capi-release).
 
 If this process works well, the idea is to switch the workflow from draft to published releases.
+
+Disable the [Release Cron](https://github.com/cloudfoundry/storage-cli/actions/workflows/release-cron.yml) workflow (3 dot button on the right > Disable workflow) to stop automatic releases, e.g. in case of known bugs on main or when a new major/minor version shall be released manually.
 
 ### Manual Release
 Releases must be triggered manually by an approver. This can be done either via `GitHub Actions` (workflow dispatch) or through the `GitHub Releases` page using the **Draft a new release** option. The *Release Manual* workflow is responsible for creating and completing the release.


### PR DESCRIPTION
Use a more odd schedule as Github may delay or skip when overloaded, even hours are not recommended. https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule

Workaround for skipped ITs because GitHub Actions does not reliably evaluate needs.<job>.outputs in if-conditions on reusable workflow call jobs, causing them to be silently
skipped.
