### PR TITLE
fix: run IT jobs for all triggers except fork PRs

### DIFF
--- a/.github/workflows/alioss-integration.yml
+++ b/.github/workflows/alioss-integration.yml
@@ -21,12 +21,10 @@ jobs:
   alioss-general-integration-tests:
     name:  Alioss General Integration Tests
     runs-on: ubuntu-latest
-    # Run on push/workflow_dispatch/workflow_call, skip fork PRs
-    if: |
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'workflow_call' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    # Skip fork PRs; run for all other triggers (push, dispatch, workflow_call, schedule, etc.)
+    if: >
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       statuses: write
     steps:

--- a/.github/workflows/azurebs-integration.yml
+++ b/.github/workflows/azurebs-integration.yml
@@ -21,12 +21,10 @@ jobs:
   azurecloud-environment-integration-tests:
     name:  AzureCloud Environment Integration Tests
     runs-on: ubuntu-latest
-    # Run on push/workflow_dispatch/workflow_call, skip fork PRs
-    if: |
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'workflow_call' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    # Skip fork PRs; run for all other triggers (push, dispatch, workflow_call, schedule, etc.)
+    if: >
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       statuses: write
     steps:

--- a/.github/workflows/dav-integration.yml
+++ b/.github/workflows/dav-integration.yml
@@ -21,11 +21,10 @@ jobs:
   dav-integration:
     name: DAV Integration Tests
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'workflow_call' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    # Skip fork PRs; run for all other triggers (push, dispatch, workflow_call, schedule, etc.)
+    if: >
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       statuses: write
     steps:

--- a/.github/workflows/gcs-integration.yml
+++ b/.github/workflows/gcs-integration.yml
@@ -21,12 +21,10 @@ jobs:
   gcs-integration-fast-tests:
     name:  GCS Integation Fast Tests
     runs-on: ubuntu-latest
-    # Run on push/workflow_dispatch/workflow_call, skip fork PRs
-    if: |
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'workflow_call' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    # Skip fork PRs; run for all other triggers (push, dispatch, workflow_call, schedule, etc.)
+    if: >
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       statuses: write
     steps:
@@ -67,12 +65,10 @@ jobs:
   gcs-integration-all-tests:
     name:  GCS Integation All Tests
     runs-on: ubuntu-latest
-    # Run on push/workflow_dispatch/workflow_call, skip fork PRs
-    if: |
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'workflow_call' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    # Skip fork PRs; run for all other triggers (push, dispatch, workflow_call, schedule, etc.)
+    if: >
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       statuses: write
     steps:

--- a/.github/workflows/release-cron.yml
+++ b/.github/workflows/release-cron.yml
@@ -2,7 +2,7 @@ name: Release Cron
 
 on:
   schedule:
-    - cron: '27 5 * * 2'  # Every Tuesday at 05:27 UTC
+    - cron: '27 5 * * 3'  # Every Wednesday at 05:27 UTC
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/s3-integration.yml
+++ b/.github/workflows/s3-integration.yml
@@ -21,12 +21,10 @@ jobs:
   aws-s3-us-integration:
     name: AWS S3 US Integration
     runs-on: ubuntu-latest
-    # Run on push/workflow_dispatch/workflow_call, skip fork PRs
-    if: |
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'workflow_call' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    # Skip fork PRs; run for all other triggers (push, dispatch, workflow_call, schedule, etc.)
+    if: >
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       statuses: write
     env:
@@ -101,12 +99,10 @@ jobs:
   aws-s3-regional-integration:
     name: AWS S3 ${{ matrix.name }} Integration
     runs-on: ubuntu-latest
-    # Run on push/workflow_dispatch/workflow_call, skip fork PRs
-    if: |
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'workflow_call' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    # Skip fork PRs; run for all other triggers (push, dispatch, workflow_call, schedule, etc.)
+    if: >
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       statuses: write
     strategy:
@@ -178,12 +174,10 @@ jobs:
   s3-compatible-integration:
     name: S3 Compatible Integration
     runs-on: ubuntu-latest
-    # Run on push/workflow_dispatch/workflow_call, skip fork PRs
-    if: |
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'workflow_call' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    # Skip fork PRs; run for all other triggers (push, dispatch, workflow_call, schedule, etc.)
+    if: >
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       statuses: write
     steps:


### PR DESCRIPTION
The previous allowlist if condition (push || workflow_dispatch || workflow_call || non-fork PR) silently skipped jobs when the caller used a schedule trigger, because reusable workflows expose the caller's event_name — not 'workflow_call'.

Replace with a denylist that runs for every event unless the PR originates from a fork, so scheduled releases and any future trigger types are handled automatically.