### PR TITLE
Switch to weekly published releases

### DIFF
--- a/.github/workflows/release-cron.yml
+++ b/.github/workflows/release-cron.yml
@@ -198,6 +198,6 @@ jobs:
             storage-cli-${{ steps.version.outputs.VERSION_NUMBER }}-darwin-arm64
             storage-cli-${{ steps.version.outputs.VERSION_NUMBER }}-windows-amd64.exe
           token: ${{ secrets.GITHUB_TOKEN }}
-          draft: true # for testing, TODO: change to false
+          draft: false
           makeLatest: true
           generateReleaseNotes: true

--- a/README.md
+++ b/README.md
@@ -141,9 +141,7 @@ Dependabot PRs are merged automatically if they pass all required checks (tests 
 
 The workflow [Release Cron](https://github.com/cloudfoundry/storage-cli/actions/workflows/release-cron.yml) builds an automatic weekly patch release if there are changes on the `main` branch (e.g. version bumps).
 
-The workflow builds and tests storage-cli, runs the integration tests and creates a **draft release** that needs to be published manually. Note that only published storage-cli releases are picked up by [capi-release](https://github.com/cloudfoundry/capi-release).
-
-If this process works well, the idea is to switch the workflow from draft to published releases.
+The workflow builds and tests storage-cli, runs the integration tests and finally builds and publishes the new patch release. Note that published storage-cli releases are picked up by [capi-release](https://github.com/cloudfoundry/capi-release) automatically.
 
 Disable the [Release Cron](https://github.com/cloudfoundry/storage-cli/actions/workflows/release-cron.yml) workflow (3 dot button on the right > Disable workflow) to stop automatic releases, e.g. in case of known bugs on main or when a new major/minor version shall be released manually.
 


### PR DESCRIPTION
So far, we had weekly draft releases that needed to be published manually. The release workflow worked out well, so we can switch now.

Note that a published storage-cli release will be consumed automatically by capi-release.