### PR TITLE
IT jobs shall queue for different PRs

### DIFF
--- a/.github/workflows/alioss-integration.yml
+++ b/.github/workflows/alioss-integration.yml
@@ -9,8 +9,8 @@ on:
       - main
 
 concurrency:
-  group: alioss-integration
-  cancel-in-progress: false
+  group: alioss-integration-${{ github.event.pull_request.head.ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   gate:
@@ -27,6 +27,10 @@ jobs:
     name: Alioss General Integration Tests
     runs-on: ubuntu-latest
     needs: [gate]
+    concurrency:
+      group: alioss-integration
+      cancel-in-progress: false
+      queue: max
     if: always() && (needs.gate.result == 'success' || needs.gate.result == 'skipped')
     steps:
       - name: Checkout code

--- a/.github/workflows/azurebs-integration.yml
+++ b/.github/workflows/azurebs-integration.yml
@@ -9,8 +9,8 @@ on:
       - main
 
 concurrency:
-  group: azurebs-integration
-  cancel-in-progress: false
+  group: azurebs-integration-${{ github.event.pull_request.head.ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   gate:
@@ -27,6 +27,10 @@ jobs:
     name: AzureCloud Environment Integration Tests
     runs-on: ubuntu-latest
     needs: [gate]
+    concurrency:
+      group: azurebs-integration
+      cancel-in-progress: false
+      queue: max
     if: always() && (needs.gate.result == 'success' || needs.gate.result == 'skipped')
     steps:
       - name: Checkout code

--- a/.github/workflows/dav-integration.yml
+++ b/.github/workflows/dav-integration.yml
@@ -9,8 +9,8 @@ on:
       - main
 
 concurrency:
-  group: dav-integration
-  cancel-in-progress: false
+  group: dav-integration-${{ github.event.pull_request.head.ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   gate:
@@ -27,6 +27,10 @@ jobs:
     name: DAV Integration Tests
     runs-on: ubuntu-latest
     needs: [gate]
+    concurrency:
+      group: dav-integration
+      cancel-in-progress: false
+      queue: max
     if: always() && (needs.gate.result == 'success' || needs.gate.result == 'skipped')
     steps:
       - name: Checkout code

--- a/.github/workflows/gcs-integration.yml
+++ b/.github/workflows/gcs-integration.yml
@@ -9,8 +9,8 @@ on:
     - "main"
 
 concurrency:
-  group: gcs-integration
-  cancel-in-progress: false
+  group: gcs-integration-${{ github.event.pull_request.head.ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   gate:
@@ -27,6 +27,10 @@ jobs:
     name: GCS Integation Fast Tests
     runs-on: ubuntu-latest
     needs: [gate]
+    concurrency:
+      group: gcs-integration
+      cancel-in-progress: false
+      queue: max
     if: always() && (needs.gate.result == 'success' || needs.gate.result == 'skipped')
     steps:
       - name: Checkout code
@@ -62,6 +66,10 @@ jobs:
     name: GCS Integation All Tests
     runs-on: ubuntu-latest
     needs: [gate]
+    concurrency:
+      group: gcs-integration
+      cancel-in-progress: false
+      queue: max
     if: always() && (needs.gate.result == 'success' || needs.gate.result == 'skipped')
     steps:
       - name: Checkout code

--- a/.github/workflows/s3-integration.yml
+++ b/.github/workflows/s3-integration.yml
@@ -9,8 +9,8 @@ on:
       - main
 
 concurrency:
-  group: s3-integration
-  cancel-in-progress: false
+  group: s3-integration-${{ github.event.pull_request.head.ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   gate:
@@ -27,6 +27,10 @@ jobs:
     name: AWS S3 US Integration
     runs-on: ubuntu-latest
     needs: [gate]
+    concurrency:
+      group: s3-integration-us
+      cancel-in-progress: false
+      queue: max
     if: always() && (needs.gate.result == 'success' || needs.gate.result == 'skipped')
     env:
       REGION_NAME: us-east-1
@@ -95,6 +99,10 @@ jobs:
     name: AWS S3 ${{ matrix.name }} Integration
     runs-on: ubuntu-latest
     needs: [gate]
+    concurrency:
+      group: s3-integration-regional
+      cancel-in-progress: false
+      queue: max
     if: always() && (needs.gate.result == 'success' || needs.gate.result == 'skipped')
     strategy:
       fail-fast: false
@@ -160,6 +168,10 @@ jobs:
     name: S3 Compatible Integration
     runs-on: ubuntu-latest
     needs: [gate]
+    concurrency:
+      group: s3-integration-compat
+      cancel-in-progress: false
+      queue: max
     if: always() && (needs.gate.result == 'success' || needs.gate.result == 'skipped')
     steps:
       - name: Checkout code


### PR DESCRIPTION
ITs got canceled when dependabot opened multiple PRs at the same time.

- IT jobs shall run for every PR
- IT jobs must be serialized per IaaS account/region
- new commits on the same PR/branch shall cancel older IT jobs