### PR TITLE
fix: re-approve dependabot PRs after rebase

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,7 +2,7 @@ name: Dependabot auto-merge
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize]
 
 permissions:
   contents: write


### PR DESCRIPTION
The auto-merge workflow only triggered on `opened`, so when dependabot rebased a PR (synchronize event), the stale-review dismissal blocked auto-merge without a re-approval.